### PR TITLE
Fix PIL Image.ANTIALIAS incompatibility

### DIFF
--- a/cirtorch/datasets/datahelpers.py
+++ b/cirtorch/datasets/datahelpers.py
@@ -1,7 +1,11 @@
 import os
 from PIL import Image
+from packaging.version import Version
 
 import torch
+
+LANCZOS = Image.LANCZOS if Version(Image.__version__) >= Version("10.0.0") else Image.ANTIALIAS
+
 
 def cid2filename(cid, prefix):
     """
@@ -40,7 +44,7 @@ def default_loader(path):
         return pil_loader(path)
 
 def imresize(img, imsize):
-    img.thumbnail((imsize, imsize), Image.ANTIALIAS)
+    img.thumbnail((imsize, imsize), LANCZOS)
     return img
 
 def flip(x, dim):


### PR DESCRIPTION
Since `Pillow>=10.0.0`, the `Image.ANTIALIAS` resampling is no longer supported and it is changed for `Image.LANCZOS`, see [pillow changelog](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html).